### PR TITLE
CMake - copy resources on build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,6 +311,10 @@ set(D6R_APP_DEBUG_NAME "duel6rd" CACHE STRING "Filename of the debug version of 
 add_executable(${D6R_APP_NAME} ${D6R_SOURCES})
 set_target_properties(${D6R_APP_NAME} PROPERTIES VERSION 4.0.1 DEBUG_OUTPUT_NAME ${D6R_APP_DEBUG_NAME})
 
+add_custom_command(TARGET ${D6R_APP_NAME} POST_BUILD
+                   COMMAND ${CMAKE_COMMAND} -E copy_directory
+                       ${CMAKE_SOURCE_DIR}/resources/ $<TARGET_FILE_DIR:${D6R_APP_NAME}>)
+
 #########################################################################
 # External dependencies
 #########################################################################
@@ -354,3 +358,7 @@ endif(APPLE)
 
 # install binary files
 install(TARGETS ${D6R_APP_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX})
+#install(DIRECTORY resources/data DESTINATION data)
+#install(DIRECTORY resources/levels DESTINATION levels)
+#install(DIRECTORY resources/sound DESTINATION sound)
+#install(DIRECTORY resources/textures DESTINATION textures)


### PR DESCRIPTION
Added copying of resources so that build is immediately runnable.
+Commented out suggestion for install target.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/odanek/duel6r/62)
<!-- Reviewable:end -->
