### PR TITLE
workaround for compilation fail with older SDL 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,10 @@ if(MSVC)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE)
 endif(MSVC)
 
+# windows
+if(WINDOWS)
+   add_definition(-DD6__WINDOWS__)
+endif(WINDOWS)
 # gnu compiler or clang
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++17")

--- a/source/Main.cpp
+++ b/source/Main.cpp
@@ -38,8 +38,9 @@ static void reportError(const std::string &err) {
 
 int main(int argc, char **argv) {
     try {
+#ifdef D6__WINDOWS__
         SDL_SetHint(SDL_HINT_WINDOWS_DISABLE_THREAD_NAMING, "1");   // Fixes GDB crashing on Mix_OpenAudio
-
+#endif
         Duel6::Application app;
         app.setup(argc, argv);
         app.run();


### PR DESCRIPTION
 - SDL_HINT_WINDOWS_DISABLE_THREAD_NAMING has been introduced in SDL 2.0.5,
compilation fails with older version, adding check for WINDOWS platform to
mitigate breaking the compilation on Linux