### PR TITLE
improve reward system - add assistance points

### DIFF
--- a/source/Menu.cpp
+++ b/source/Menu.cpp
@@ -181,7 +181,7 @@ namespace Duel6 {
         label[0] = new Gui::Label(gui);
         label[0]->setPosition(10, 219, 800, 18);
         label[0]->setCaption(
-                "    Name   | Games | Wins | Shots | Acc. | Kills | Assists | Pen | PTS | Alive | Damage | Time");
+                "    Name   | Games | Wins | Shots | Acc. | Kills | Assists | Pen | PTS | Alive | Damage  | Time");
 
         label[1] = new Gui::Label(gui);
         label[1]->setPosition(520, 418, 125, 18);
@@ -311,7 +311,7 @@ namespace Duel6 {
 
         for (auto person : ranking) {
             std::string personStat =
-                    Format("{0,-11}|{1,6} |{2,5} |{3,6} |{4,4}% |{5,6} | {6,7} | {7,3} |{8,4} |{9,5}% |{10,7} |{11,4}m ")
+                    Format("{0,-11}|{1,6} |{2,5} |{3,6} |{4,4}% |{5,6} | {6,7} | {7,3} |{8,4} |{9,5}% |{10,4}|{12,4}|{11,4}m ")
                             << person->getName()
                             << person->getGames()
                             << person->getWins()
@@ -323,7 +323,8 @@ namespace Duel6 {
                             << person->getTotalPoints()
                             << person->getAliveRatio()
                             << person->getTotalDamage()
-                            << (person->getTotalGameTime() + 30) / 60;
+                            << (person->getTotalGameTime() + 30) / 60
+                            << person->getAssistedDamage();
             listbox[0]->addItem(personStat);
         }
     }

--- a/source/Menu.cpp
+++ b/source/Menu.cpp
@@ -181,7 +181,7 @@ namespace Duel6 {
         label[0] = new Gui::Label(gui);
         label[0]->setPosition(10, 219, 800, 18);
         label[0]->setCaption(
-                "    Name   | Games | Wins | Shots | Accuracy | Kills | Penalties | Points | Alive | Damage | Time");
+                "    Name   | Games | Wins | Shots | Acc. | Kills | Assists | Pen | PTS | Alive | Damage | Time");
 
         label[1] = new Gui::Label(gui);
         label[1]->setPosition(520, 418, 125, 18);
@@ -311,13 +311,14 @@ namespace Duel6 {
 
         for (auto person : ranking) {
             std::string personStat =
-                    Format("{0,-11}|{1,6} |{2,5} |{3,6} |{4,8}% |{5,6} |{6,10} |{7,7} |{8,5}% |{9,6} |{10,4}m ")
+                    Format("{0,-11}|{1,6} |{2,5} |{3,6} |{4,4}% |{5,6} | {6,7} | {7,3} |{8,4} |{9,5}% |{10,7} |{11,4}m ")
                             << person->getName()
                             << person->getGames()
                             << person->getWins()
                             << person->getShots()
                             << person->getAccuracy()
                             << person->getKills()
+                            << person->getAssistances()
                             << person->getPenalties()
                             << person->getTotalPoints()
                             << person->getAliveRatio()

--- a/source/Person.cpp
+++ b/source/Person.cpp
@@ -32,6 +32,7 @@ namespace Duel6 {
         shots = 0;
         hits = 0;
         kills = 0;
+        assistances = 0;
         wins = 0;
         games = 0;
         penalties = 0;
@@ -47,6 +48,7 @@ namespace Duel6 {
         json.set("shots", Json::Value::makeNumber(shots));
         json.set("hits", Json::Value::makeNumber(hits));
         json.set("kills", Json::Value::makeNumber(kills));
+        json.set("assistances", Json::Value::makeNumber(assistances));
         json.set("wins", Json::Value::makeNumber(wins));
         json.set("penalties", Json::Value::makeNumber(penalties));
         json.set("games", Json::Value::makeNumber(games));
@@ -62,6 +64,7 @@ namespace Duel6 {
         person.shots = json.get("shots").asInt();
         person.hits = json.get("hits").asInt();
         person.kills = json.get("kills").asInt();
+        person.assistances = json.getOrDefault("assistances", Json::Value::makeNumber(0)).asInt();
         person.wins = json.get("wins").asInt();
         person.penalties = json.get("penalties").asInt();
         person.games = json.get("games").asInt();

--- a/source/Person.cpp
+++ b/source/Person.cpp
@@ -39,6 +39,7 @@ namespace Duel6 {
         timeAlive = 0;
         totalGameTime = 0;
         totalDamage = 0;
+        assistedDamage = 0;
         return *this;
     }
 
@@ -55,6 +56,7 @@ namespace Duel6 {
         json.set("timeAlive", Json::Value::makeNumber(timeAlive));
         json.set("totalGameTime", Json::Value::makeNumber(totalGameTime));
         json.set("totalDamage", Json::Value::makeNumber(totalDamage));
+        json.set("assistedDamage", Json::Value::makeNumber(assistedDamage));
         return json;
     }
 
@@ -71,6 +73,7 @@ namespace Duel6 {
         person.timeAlive = json.get("timeAlive").asInt();
         person.totalGameTime = json.get("totalGameTime").asInt();
         person.totalDamage = json.getOrDefault("totalDamage", Json::Value::makeNumber(0)).asInt();
+        person.assistedDamage = json.getOrDefault("assistedDamage", Json::Value::makeNumber(0)).asInt();
         return person;
     }
 }

--- a/source/Person.h
+++ b/source/Person.h
@@ -41,6 +41,7 @@ namespace Duel6 {
         Int32 shots;
         Int32 hits;
         Int32 kills;
+        Int32 assistances;
         Int32 wins;
         Int32 penalties;
         Int32 games;
@@ -50,7 +51,7 @@ namespace Duel6 {
 
     public:
         Person()
-                : shots(0), hits(0), kills(0), wins(0), penalties(0), games(0), timeAlive(0), totalGameTime(0),
+                : shots(0), hits(0), kills(0), assistances(0), wins(0), penalties(0), games(0), timeAlive(0), totalGameTime(0),
                   totalDamage(0) {}
 
         explicit Person(const std::string &name)
@@ -74,6 +75,10 @@ namespace Duel6 {
             return kills;
         }
 
+        Int32 getAssistances() const {
+            return assistances;
+        }
+
         Int32 getWins() const {
             return wins;
         }
@@ -91,7 +96,7 @@ namespace Duel6 {
         }
 
         Int32 getTotalPoints() const {
-            return getKills() + getWins() - getPenalties();
+            return getKills() + getWins() + getAssistances() - getPenalties();
         }
 
         Int32 getTimeAlive() const {
@@ -122,6 +127,11 @@ namespace Duel6 {
 
         Person &addKills(Int32 kills) {
             this->kills += kills;
+            return *this;
+        }
+
+        Person &addAssistances(Int32 assistances) {
+            this->assistances += assistances;
             return *this;
         }
 

--- a/source/Person.h
+++ b/source/Person.h
@@ -48,11 +48,12 @@ namespace Duel6 {
         Int32 timeAlive;
         Int32 totalGameTime;
         Int32 totalDamage;
+        Int32 assistedDamage;
 
     public:
         Person()
                 : shots(0), hits(0), kills(0), assistances(0), wins(0), penalties(0), games(0), timeAlive(0), totalGameTime(0),
-                  totalDamage(0) {}
+                  totalDamage(0), assistedDamage(0) {}
 
         explicit Person(const std::string &name)
                 : Person() {
@@ -115,6 +116,10 @@ namespace Duel6 {
             return totalDamage;
         }
 
+        Int32 getAssistedDamage() const {
+            return assistedDamage;
+        }
+
         Person &addShots(Int32 shots) {
             this->shots += shots;
             return *this;
@@ -160,6 +165,10 @@ namespace Duel6 {
 
         void addDamageCaused(Int32 damageCaused) {
             this->totalDamage += damageCaused;
+        }
+
+        void addAssistedDamage(Int32 damageCaused) {
+            this->assistedDamage += damageCaused;
         }
 
         bool hasHigherScoreThan(const Person &person) const {

--- a/source/Player.cpp
+++ b/source/Player.cpp
@@ -831,7 +831,7 @@ namespace Duel6 {
 
         if (suicide) {
             playSound(PlayerSounds::Type::Suicide);
-            eventListener->onSuicide(*this, playersKilled.size() - 1);
+            eventListener->onSuicide(*this, playersKilled);
         } else if (!playersKilled.empty()) {
             playSound(PlayerSounds::Type::KilledOther);
         }

--- a/source/Player.h
+++ b/source/Player.h
@@ -261,7 +261,6 @@ namespace Duel6 {
             Water headUnderWater;
             Water feetInWater;
         };
-
     private:
         Person &person;
         PlayerSkin skin;

--- a/source/PlayerEventListener.cpp
+++ b/source/PlayerEventListener.cpp
@@ -33,6 +33,7 @@ namespace Duel6 {
                                              bool directHit) {
         if (!player.is(shootingPlayer)) {
             shootingPlayer.getPerson().addDamageCaused(std::min((Int32) amount, (Int32) player.getLife()));
+            attackers[&player].insert(&shootingPlayer);
         }
         player.addLife(-amount);
         return true;
@@ -44,14 +45,22 @@ namespace Duel6 {
     }
 
     void PlayerEventListener::onKillByPlayer(Player &player, Player &killer, Shot &shot, bool suicide) {
+        onKill(player, killer, shot, suicide);
+        auto assistants = attackers[&player];
+        assistants.erase(&killer);
+        if(assistants.size() > 0){
+            onAssistedKill(player, killer, assistants, suicide);
+        }
+        addKillMessage(player, killer, assistants, suicide);
+    }
+
+    void PlayerEventListener::onKill(Player &player, Player &killer, Shot &shot, bool suicide){
         if (suicide) {
-            messageQueue.add(killer, Format("killed also [{0}]") << player.getPerson().getName());
             if (gameSettings.getScreenMode() == ScreenMode::SplitScreen) {
                 messageQueue.add(player, Format("killed by suicide of [{0}]") << killer.getPerson().getName());
             }
             killer.getPerson().addPenalties(1);
         } else {
-            messageQueue.add(killer, Format("killed [{0}]") << player.getPerson().getName());
             if (gameSettings.getScreenMode() == ScreenMode::SplitScreen) {
                 messageQueue.add(player, Format("killed by [{0}]") << killer.getPerson().getName());
             }
@@ -59,7 +68,26 @@ namespace Duel6 {
             killer.addRoundKills(1);
         }
     }
-
+    void PlayerEventListener::addKillMessage(Player &killed, Player &killer, const std::set<Player *> &assistants, bool suicide) {
+        if (suicide) {
+            //handled by addSuicideMessage()
+        } else {
+            std::string assistedByMessage = "";
+            if (assistants.size() > 0) {
+                assistedByMessage = ", assisted by: ";
+                bool first = true;
+                for (auto assistant : assistants) {
+                    if (first) {
+                        first = false;
+                    } else {
+                        assistedByMessage += ", ";
+                    }
+                    assistedByMessage += assistant->getPerson().getName();
+                }
+            }
+            messageQueue.add(killer, Format("killed [{0}]{1}") << killed.getPerson().getName() << assistedByMessage);
+        }
+    }
 
     void PlayerEventListener::onKillByEnv(Player &player) {
         //TODO: Change of behavior - when killed by bonus, player gets a penalty point!
@@ -68,13 +96,58 @@ namespace Duel6 {
         messageQueue.add(player, "You are dead");
     }
 
-    void PlayerEventListener::onSuicide(Player &player, Size otherKilledPlayers) {
+    void PlayerEventListener::onSuicide(Player &player, std::vector<Player *> &playersKilled) {
         player.getPerson().addPenalties(1);
-        messageQueue.add(player, "Committed suicide");
+
+        auto assistants = attackers[&player];
+        onAssistedSuicide(player, assistants);
+        addSuicideMessage(player, assistants, playersKilled);
+    }
+
+    void PlayerEventListener::addSuicideMessage(Player &player, const std::set<Player *> &assistants, std::vector<Player *> &playersKilled) {
+        std::string assistedMessage = "";
+        std::string killedAlsoMessage = "";
+        if (assistants.size() > 0) {
+            bool first = true;
+            for (auto assistant : assistants) {
+                if (first) {
+                    first = false;
+                    assistedMessage = ", assisted by: ";
+                } else {
+                    assistedMessage += ", ";
+                }
+                assistedMessage += assistant->getPerson().getName();
+            }
+        }
+        bool first = true;
+        for (auto killed: playersKilled){
+            if(killed != &player){
+                if (first) {
+                    first = false;
+                    killedAlsoMessage = ", killed also: ";
+                } else {
+                    killedAlsoMessage += ", ";
+                }
+                killedAlsoMessage += killed->getPerson().getName();
+            }
+        }
+        messageQueue.add(player, Format("Commited suicide{0}{1}") << assistedMessage << killedAlsoMessage);
+    }
+
+    void PlayerEventListener::onAssistedSuicide(Player &player, const std::set<Player *> &assistants) {
+        for (auto assistant : assistants) {
+            assistant->getPerson().addAssistances(1);
+        }
     }
 
     void PlayerEventListener::onRoundWin(Player &player) {
         messageQueue.add(player, "You won the round");
         player.getPerson().addWins(1);
+    }
+
+    void PlayerEventListener::onAssistedKill(Player &killed, Player &killer, const std::set<Player *> &assistants, bool suicide) {
+        for (auto assistant : assistants) {
+            assistant->getPerson().addAssistances(1);
+        }
     }
 }

--- a/source/PlayerEventListener.h
+++ b/source/PlayerEventListener.h
@@ -28,6 +28,10 @@
 #ifndef DUEL6_PLAYEREVENTLISTENER_H
 #define DUEL6_PLAYEREVENTLISTENER_H
 
+#include <map>
+#include <set>
+#include <memory>
+
 #include "InfoMessageQueue.h"
 #include "GameSettings.h"
 #include "Player.h"
@@ -35,13 +39,25 @@
 
 namespace Duel6 {
     class PlayerEventListener {
+
     protected:
         InfoMessageQueue &messageQueue;
         const GameSettings &gameSettings;
 
+        std::map<const Player *, std::set<Player *>> attackers;
+
+        virtual void addKillMessage(Player &killed, Player &killer, const std::set<Player *> &assistants, bool suicide);
+
+        virtual void addSuicideMessage(Player &player, const std::set<Player *> &assistants, std::vector<Player *> &playersKilled);
+
+        virtual void onAssistedSuicide(Player &player, const std::set<Player *> &assistants);
+
+        virtual void onAssistedKill(Player &killed, Player &killer, const std::set<Player *> &assistants, bool suicide);
+
+        virtual void onKill(Player &player, Player &killer, Shot &shot, bool suicide);
     public:
         PlayerEventListener(InfoMessageQueue &messageQueue, const GameSettings &gameSettings)
-                : messageQueue(messageQueue), gameSettings(gameSettings) {}
+                : messageQueue(messageQueue), gameSettings(gameSettings), attackers() {}
 
         virtual ~PlayerEventListener() {}
 
@@ -57,12 +73,12 @@ namespace Duel6 {
          */
         virtual bool onDamageByEnv(Player &player, Float32 amount);
 
-        virtual void onKillByPlayer(Player &player, Player &killer, Shot &shot, bool suicide);
+        virtual void onKillByPlayer(Player &player, Player &killer, Shot &shot, bool suicide) final;
 
         //TODO: Environment type (eg. water, lava, bonus)
         virtual void onKillByEnv(Player &player);
 
-        virtual void onSuicide(Player &player, Size otherKilledPlayers);
+        virtual void onSuicide(Player &player, std::vector<Player *> &playersKilled);
 
         virtual void onRoundWin(Player &player);
     };

--- a/source/Shot.h
+++ b/source/Shot.h
@@ -63,11 +63,13 @@ namespace Duel6 {
 
         virtual Rectangle getCollisionRect() const = 0;
 
-        virtual bool requestCollision(const ShotHit &hit) = 0;
+        virtual bool requestCollision(Shot &shot) = 0;
 
         virtual void onHitPlayer(Player &player, bool directHit, const Vector &hitPoint, World &world) = 0;
 
         virtual void onKillPlayer(Player &player, bool directHit, const Vector &hitPoint, World &world) = 0;
+
+        virtual ShotHit getShotHit() = 0;
     };
 }
 

--- a/source/gamemodes/TeamDeathMatchPlayerEventListener.h
+++ b/source/gamemodes/TeamDeathMatchPlayerEventListener.h
@@ -38,14 +38,20 @@ namespace Duel6 {
         bool friendlyFire;
         const TeamMap &teamMap;
 
+    protected:
+        void addKillMessage(Player &killed, Player &killer, const std::set<Player *> &assistants, bool suicide) override;
+
+        void onAssistedKill(Player &killed, Player &killer, const std::set<Player *> &assistants, bool suicide) override;
+
+        void onAssistedSuicide(Player &player, const std::set<Player *> &assistants) override;
+
+        void onKill(Player &player, Player &killer, Shot &shot, bool suicice) override;
     public:
         TeamDeathMatchPlayerEventListener(InfoMessageQueue &messageQueue, const GameSettings &gameSettings,
                                           bool friendlyFire, const TeamMap &teamMap)
                 : PlayerEventListener(messageQueue, gameSettings), friendlyFire(friendlyFire), teamMap(teamMap) {}
 
-        bool onDamageByShot(Player &player, Player &shootingPlayer, Float32 amount, Shot &shot, bool directHit);
-
-        void onKillByPlayer(Player &player, Player &killer, Shot &shot, bool suicice);
+        bool onDamageByShot(Player &player, Player &shootingPlayer, Float32 amount, Shot &shot, bool directHit) override;
     };
 }
 

--- a/source/gamemodes/TeamDeathMatchPlayerEventListener.h
+++ b/source/gamemodes/TeamDeathMatchPlayerEventListener.h
@@ -39,11 +39,11 @@ namespace Duel6 {
         const TeamMap &teamMap;
 
     protected:
-        void addKillMessage(Player &killed, Player &killer, const std::set<Player *> &assistants, bool suicide) override;
+        void addKillMessage(Player &killed, Player &killer, const AssistanceList &assistances, bool suicide) override;
 
-        void onAssistedKill(Player &killed, Player &killer, const std::set<Player *> &assistants, bool suicide) override;
+        void onAssistedKill(Player &killed, Player &killer, const AssistanceList &assistances, bool suicide) override;
 
-        void onAssistedSuicide(Player &player, const std::set<Player *> &assistants) override;
+        void onAssistedSuicide(Player &player, const AssistanceList &assistances) override;
 
         void onKill(Player &player, Player &killer, Shot &shot, bool suicice) override;
     public:

--- a/source/weapon/LegacyShot.h
+++ b/source/weapon/LegacyShot.h
@@ -49,7 +49,7 @@ namespace Duel6 {
         Vector velocity;
         SpriteList::Iterator sprite;
         bool powerful;
-        Shot *hitByOtherShot;
+        ShotHit shotHit;
 
     public:
         LegacyShot(Player &player, const LegacyWeapon &weapon, Orientation orientation, SpriteList::Iterator sprite,
@@ -61,11 +61,13 @@ namespace Duel6 {
             return Rectangle::fromCornerAndSize(getPosition(), getDimensions());
         }
 
-        bool requestCollision(const ShotHit &hit) override;
+        bool requestCollision(Shot &shot) override;
 
         void onHitPlayer(Player &player, bool directHit, const Vector &hitPoint, World &world) override;
 
         void onKillPlayer(Player &player, bool directHit, const Vector &hitPoint, World &world) override;
+
+        ShotHit getShotHit() override;
 
     protected:
         virtual void onExplode(const Vector &centre, Float32 range, World &world);
@@ -104,7 +106,7 @@ namespace Duel6 {
 
         ShotHit checkShotCollision(ShotList &shotList, ShotCollisionSetting collisionSetting);
 
-        void explode(ShotHit hit, World &world);
+        void explode(World &world);
 
         void addPlayerExplosion(Player &player, World &world);
 


### PR DESCRIPTION
 - on player's death all his previous attackers get an assistance point
 - Team Deathmatch
   - only teammates are awarded by assistance when making a kill
   - on suicde kills assistance points are not awarded to the suicider's teammates