### PR TITLE
Allow to specify 'background' for each level

### DIFF
--- a/source/Game.cpp
+++ b/source/Game.cpp
@@ -131,12 +131,11 @@ namespace Duel6 {
         Int32 level = shuffle ? playedRounds % Int32(levels.size()) : Math::random(Int32(levels.size()));
         const std::string levelPath = levels[level];
         bool mirror = Math::random(2) == 0;
-        Size background = backgrounds[Math::random(Int32(backgrounds.size()))];
 
         Console &console = appService.getConsole();
         console.printLine(Format("\n===Loading level {0}===") << levelPath);
-        console.printLine(Format("...Parameters: mirror: {0}, background: {1}") << mirror << background);
-        round = std::make_unique<Round>(*this, playedRounds, players, levelPath, mirror, background);
+        console.printLine(Format("...Parameters: mirror: {0}") << mirror);
+        round = std::make_unique<Round>(*this, playedRounds, players, levelPath, mirror);
 
         playedRounds++;
         resources.getRoundStartSound().play();

--- a/source/Game.h
+++ b/source/Game.h
@@ -125,6 +125,10 @@ namespace Duel6 {
             return appService;
         }
 
+        const std::vector<Size> &getBackgrounds() const {
+            return backgrounds;
+        }
+
         std::vector<Player> &getPlayers() {
             return players;
         }

--- a/source/Level.cpp
+++ b/source/Level.cpp
@@ -26,13 +26,15 @@
 */
 
 #include <queue>
+#include "Game.h"
 #include "Level.h"
 #include "json/JsonParser.h"
 #include "GameException.h"
 
 namespace Duel6 {
-    Level::Level(const std::string &path, bool mirror, const Block::Meta &blockMeta)
-            : blockMeta(blockMeta) {
+    Level::Level(Game &game, const std::string &path, bool mirror)
+            : blockMeta(game.getResources().getBlockMeta()),
+              backgrounds(game.getBackgrounds()) {
         load(path, mirror);
     }
 
@@ -43,6 +45,15 @@ namespace Duel6 {
 
         width = root.get("width").asInt();
         height = root.get("height").asInt();
+
+        Size randomBackground = backgrounds[Math::random(backgrounds.size())];
+        Size customBackground = root.getOrDefault("background", Json::Value::makeNumber(Int32(randomBackground))).asInt();
+
+        if (std::find(backgrounds.begin(), backgrounds.end(), customBackground) != backgrounds.end()) {
+            background = customBackground;
+        } else {
+            background = randomBackground;
+        }
 
         Int32 blockCount = width * height;
         Json::Value blocks = root.get("blocks");

--- a/source/Level.h
+++ b/source/Level.h
@@ -35,6 +35,8 @@
 #include "Water.h"
 
 namespace Duel6 {
+    class Game;
+
     class Level {
     public:
         typedef std::pair<Int32, Int32> StartingPosition;
@@ -42,14 +44,16 @@ namespace Duel6 {
 
     private:
         const Block::Meta &blockMeta;
+        const std::vector<Size> &backgrounds;
         Int32 width;
         Int32 height;
+        Size background;
         std::vector<Uint16> levelData;
         Uint16 waterBlock;
         Int32 waterLevel;
 
     public:
-        Level(const std::string &path, bool mirror, const Block::Meta &blockMeta);
+        Level(Game &game, const std::string &path, bool mirror);
 
         Int32 getWidth() const {
             return width;
@@ -57,6 +61,10 @@ namespace Duel6 {
 
         Int32 getHeight() const {
             return height;
+        }
+
+        Size getBackground() const {
+            return background;
         }
 
         bool isEmpty(Int32 x, Int32 y) const {

--- a/source/Round.cpp
+++ b/source/Round.cpp
@@ -33,9 +33,8 @@
 #include "Weapon.h"
 
 namespace Duel6 {
-    Round::Round(Game &game, Int32 roundNumber, std::vector<Player> &players, const std::string &levelPath, bool mirror,
-                 Size background)
-            : game(game), roundNumber(roundNumber), world(game, levelPath, mirror, background),
+    Round::Round(Game &game, Int32 roundNumber, std::vector<Player> &players, const std::string &levelPath, bool mirror)
+            : game(game), roundNumber(roundNumber), world(game, levelPath, mirror),
               suddenDeathMode(false), waterFillWait(0), showYouAreHere(D6_YOU_ARE_HERE_DURATION), gameOverWait(0),
               winner(false) {
         preparePlayers();

--- a/source/Round.h
+++ b/source/Round.h
@@ -50,8 +50,7 @@ namespace Duel6 {
         std::vector<Player *> alivePlayers;
 
     public:
-        Round(Game &game, Int32 roundNumber, std::vector<Player> &players, const std::string &levelPath, bool mirror,
-              Size background);
+        Round(Game &game, Int32 roundNumber, std::vector<Player> &players, const std::string &levelPath, bool mirror);
 
         void update(Float32 elapsedTime);
 

--- a/source/World.cpp
+++ b/source/World.cpp
@@ -30,12 +30,12 @@
 #include "Weapon.h"
 
 namespace Duel6 {
-    World::World(Game &game, const std::string &levelPath, bool mirror, Size background)
+    World::World(Game &game, const std::string &levelPath, bool mirror)
             : gameSettings(game.getSettings()), players(game.getPlayers()),
-              level(levelPath, mirror, game.getResources().getBlockMeta()),
+              level(game, levelPath, mirror),
               levelRenderData(level, D6_ANM_SPEED, D6_WAVE_HEIGHT), messageQueue(D6_INFO_DURATION),
               explosionList(game.getResources(), D6_EXPL_SPEED), fireList(game.getResources(), spriteList),
-              background(background), bonusList(game.getSettings(), game.getResources(), *this),
+              bonusList(game.getSettings(), game.getResources(), *this),
               elevatorList(game.getResources().getElevatorTextures()) {
         Console &console = game.getAppService().getConsole();
         console.printLine(Format("...Width   : {0}") << level.getWidth());

--- a/source/World.h
+++ b/source/World.h
@@ -51,12 +51,11 @@ namespace Duel6 {
         ShotList shotList;
         ExplosionList explosionList;
         FireList fireList;
-        Size background;
         BonusList bonusList;
         ElevatorList elevatorList;
 
     public:
-        World(Game &game, const std::string &levelPath, bool mirror, Size background);
+        World(Game &game, const std::string &levelPath, bool mirror);
 
         void update(Float32 elapsedTime);
 
@@ -131,7 +130,7 @@ namespace Duel6 {
         }
 
         Size getBackground() const {
-            return background;
+            return level.getBackground();
         }
 
         BonusList &getBonusList() {


### PR DESCRIPTION
You can add 'background' property (integer) to a level JSON file to bind level with specific background.