### PR TITLE
Gamepads - small improvements

### DIFF
--- a/source/Application.cpp
+++ b/source/Application.cpp
@@ -159,7 +159,13 @@ namespace Duel6 {
                 case SDL_JOYDEVICEADDED:{
                     auto deviceIndex = event.jdevice.which;
                     auto joy = SDL_JoystickOpen(deviceIndex);
-                    joyDeviceAddedEvent(context, JoyDeviceAddedEvent(joy));
+                    if(SDL_JoystickGetAttached(joy)){
+                        joyDeviceAddedEvent(context, JoyDeviceAddedEvent(joy));
+                    } else {
+                        console.printLine(Format("Joy attached, but has been detached again -> skipping."));
+                        break;
+                    }
+
                     break;
                 }
                 case SDL_JOYDEVICEREMOVED: {

--- a/source/Menu.cpp
+++ b/source/Menu.cpp
@@ -379,18 +379,7 @@ namespace Duel6 {
         bool detected = false;
 
         while (!detected) {
-            if (SDL_PollEvent(&event)) {
-                switch (event.type) {
-                    case SDL_KEYDOWN:
-                        key = event.key.keysym;
-                        appService.getInput().setPressed(key.sym, true);
-                        break;
-                    case SDL_KEYUP:
-                        key = event.key.keysym;
-                        appService.getInput().setPressed(key.sym, false);
-                        break;
-                }
-
+            if (processEvents(true)) {
                 for (Size i = 0; i < controlsManager.getNumAvailable(); i++) {
                     const PlayerControls &pc = controlsManager.get(i);
 
@@ -644,12 +633,53 @@ namespace Duel6 {
 
         return nullptr;
     }
-
-    void Menu::consumeInputEvents() {
+    int Menu::processEvents(bool single) {
         SDL_Event event;
-        while (SDL_PollEvent(&event)) {
-            // Eat all remaining keyboard events;
+        int result = 0;
+        //TODO This logic duplicates event processing logic in Application. Should be refactored.
+        while ((result = SDL_PollEvent(&event)) != 0) {
+            switch (event.type) {
+                case SDL_KEYDOWN:{
+                    auto key = event.key.keysym;
+                    appService.getInput().setPressed(key.sym, true);
+                    break;
+                }
+                case SDL_KEYUP:{
+                    auto key = event.key.keysym;
+                    appService.getInput().setPressed(key.sym, false);
+                    break;
+                }
+                case SDL_JOYDEVICEADDED:{
+                    appService.getConsole().printLine("Device added");
+
+                    auto deviceIndex = event.jdevice.which;
+                    auto joy = SDL_JoystickOpen(deviceIndex);
+                    if(SDL_JoystickGetAttached(joy)){
+                       appService.getInput().joyAttached(joy);
+                       joyRescan();
+                    } else {
+                        appService.getConsole().printLine(Format("Joy attached, but has been detached again -> skipping."));
+                        break;
+                    }
+
+                    break;
+                }
+                case SDL_JOYDEVICEREMOVED: {
+                    appService.getConsole().printLine("Device removed");
+                    auto instanceId = event.jdevice.which;
+                    appService.getInput().joyDetached(instanceId);
+                    joyRescan();
+                    break;
+                }
+            }
+            if(single){
+                return result;
+            }
         }
+        return result;
+    }
+    void Menu::consumeInputEvents() {
+        processEvents();
     }
 
     void Menu::shufflePlayers() {

--- a/source/Menu.h
+++ b/source/Menu.h
@@ -158,6 +158,8 @@ namespace Duel6 {
 
         bool deleteQuestion();
 
+        int processEvents(bool single = true);
+
         void consumeInputEvents();
 
         void shufflePlayers();

--- a/source/gamecontroller/GameController.cpp
+++ b/source/gamecontroller/GameController.cpp
@@ -13,8 +13,9 @@ GameController::GameController(Instance instance):
         open(SDL_bool::SDL_TRUE == SDL_JoystickGetAttached(instance)),
         instance(instance),
         instanceID(SDL_JoystickInstanceID(instance)),
-        guid(SDL_JoystickGetGUID(instance)),
-        name(SDL_JoystickName(instance)){
+        guid(SDL_JoystickGetGUID(instance)) {
+        auto joyName = SDL_JoystickName(instance);
+        name = joyName != NULL ? std::string(joyName): "<unknown>"; // unlikely to happen
 
 }
 


### PR DESCRIPTION
 - enable reattaching gamepads during player's controls assignment
 - [Linux] fix timing issue/exception thrown when processing the JOYDEVICEADDED event after the device has been detached already (some gamepads simply detach from the system when attached and reattach as completely different device just a fraction of second later)