### PR TITLE
Fix double jumps

### DIFF
--- a/source/Player.cpp
+++ b/source/Player.cpp
@@ -146,14 +146,13 @@ namespace Duel6 {
             }
 
         }
-        // player can perform a double jump after the jump peak
+        // player can perform a double jump
         // fast movement bonus unlocks super double jump
-        if (hasFlag(FlagDoubleJump)) {
-            if (collider.velocity.y < 0.0) {
-                collider.velocity.y = JUMP_ACCELERATION;
-            }
-            else if (getBonus() == BonusType::FAST_MOVEMENT) {
+        if (hasFlag(FlagDoubleJump) || (collider.velocity.y > 0 && hasFlag(FlagDoubleJumpDebounce | FlagDoubleJumpReset) && getBonus() == BonusType::FAST_MOVEMENT)) {
+            if (collider.velocity.y > 0 && getBonus() == BonusType::FAST_MOVEMENT) {
                 collider.acceleration.y += JUMP_ACCELERATION;
+            } else {
+                collider.velocity.y = JUMP_ACCELERATION;
             }
             unsetFlag(FlagDoubleJumpReset);
             unsetFlag(FlagDoubleJumpDebounce);
@@ -343,8 +342,12 @@ namespace Duel6 {
             }
             unsetFlag(FlagDoubleJump);
             if (controllerState & ButtonUp) {
-                if (hasFlag(FlagDoubleJumpDebounce | FlagDoubleJumpReset) && !isOnGround() && !isOnElevator() && !hasFlag(FlagMoveUp)) {
-                    setFlag(FlagDoubleJump);
+                if(!hasFlag(FlagMoveUp) && !collider.isOnHardSurface() && hasFlag(FlagDoubleJumpReset)) {
+                    if (hasFlag(FlagDoubleJumpDebounce)) {
+                        setFlag(FlagDoubleJump);
+                    } else {
+                        setFlag(FlagDoubleJumpDebounce);
+                    }
                 }
                 setFlag(FlagMoveUp);
             } else {
@@ -352,11 +355,6 @@ namespace Duel6 {
             }
             if (collider.isOnHardSurface()) {
                 setFlag(FlagDoubleJumpReset);
-            }
-            if (collider.isOnHardSurface() || (collider.velocity.y < 0.0 && hasFlag(FlagMoveUp))) {
-                setFlag(FlagDoubleJumpDebounce);
-            }
-            if (collider.hasStartedFalling()) {
                 unsetFlag(FlagDoubleJumpDebounce);
             }
             if (controllerState & ButtonPick) {
@@ -380,7 +378,6 @@ namespace Duel6 {
         }
 
         unsetFlag(FlagKnee);
-
         if (controllerState & ButtonDown) {
             fall();
         }

--- a/source/collision/WorldCollision.cpp
+++ b/source/collision/WorldCollision.cpp
@@ -44,9 +44,6 @@ void CollidingEntity::collideWithElevators(ElevatorList & elevators, Float32 ela
         }
     }
 }
-bool CollidingEntity::hasStartedFalling() const {
-    return startedFalling;
-}
 
 void CollidingEntity::collideWithLevel(const Level & level, Float32 elapsedTime, Float32 speed) {
     static bool bleft = false, bright = false, bup = false, bdown = false;
@@ -65,7 +62,6 @@ void CollidingEntity::collideWithLevel(const Level & level, Float32 elapsedTime,
         lastCollisionCheck.clearForJump = !level.isWall(left, up, true) && !level.isWall(right, up, true);
     }
     lastCollisionCheck.inWall = level.isWall(Int32(getCollisionRect().getCentre().x), Int32(getCollisionRect().getCentre().y), true);
-    bool wasNotFalling = velocity.y > 0 || isOnHardSurface();
     if (!isOnElevator()) {
        velocity.y += GRAVITATIONAL_ACCELERATION * elapsedTime;    // gravity
     }
@@ -210,7 +206,6 @@ void CollidingEntity::collideWithLevel(const Level & level, Float32 elapsedTime,
 
     position.y += totalSpeed.y * speed; // the speed has the elapsedTime already factored in
     position.x += totalSpeed.x * D6_PLAYER_ACCEL * speed; // the speed has the elapsedTime already factored in
-    startedFalling = wasNotFalling && velocity.y <= 0;
     lastCollisionCheck.up = bup;
     lastCollisionCheck.right = bright;
     lastCollisionCheck.down = bdown;

--- a/source/collision/WorldCollision.h
+++ b/source/collision/WorldCollision.h
@@ -86,12 +86,10 @@ namespace Duel6 {
         bool isUnderHardSurface() const;
         bool isOnElevator() const;
         bool isOnGround() const;
-        bool hasStartedFalling() const;
 
     private:
         Vector boundingBoxHorizontal = {HORIZONTAL_DELTA, DELTA_HEIGHT};
         Vector boundingBoxVertical = {VERTICAL_DELTA, DELTA_HEIGHT};
-        bool startedFalling = false;
         void checkElevator(Float32 speed);
     };
 }


### PR DESCRIPTION
 - the smoothest user experience possible - no glitches, no double taps missed, pure action
 - player can perform one double jump under any circumstances - doesn't matter if rising,falling or in the liquid - after pressing the jump button twice while in the air already
 - staying consistent with double jumps while having the fast movement bonus - super jump is still possible straight from the ground after double-tapping the jump button