### PR TITLE
Cau Ondro, mohl bys prosim vyzkouset GL4 renderer na Intel GPU? (depth buffer issue)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,6 +308,8 @@ set(D6R_SOURCES
         source/math/Vector.h
 
         source/renderer/RendererTypes.h
+        source/renderer/RendererTarget.h
+        source/renderer/RendererTarget.cpp
         source/renderer/RendererBase.h
         source/renderer/RendererBase.cpp
 

--- a/source/Color.h
+++ b/source/Color.h
@@ -61,6 +61,13 @@ namespace Duel6 {
             set(red, green, blue, alpha);
         }
 
+        void operator=(const Color & c){
+            color[0] = c.color[0];
+            color[1] = c.color[1];
+            color[2] = c.color[2];
+            color[3] = c.color[3];
+        }
+
         bool operator==(const Color &color) const {
             return (getRed() == color.getRed() &&
                     getGreen() == color.getGreen() &&

--- a/source/Color.h
+++ b/source/Color.h
@@ -54,6 +54,13 @@ namespace Duel6 {
         explicit Color(Uint8 value)
                 : Color(value, value, value, 255) {}
 
+        Color(const Color & c) {
+            color[0] = c.color[0];
+            color[1] = c.color[1];
+            color[2] = c.color[2];
+            color[3] = c.color[3];
+        }
+
         Color(Uint8 red, Uint8 green, Uint8 blue)
                 : Color(red, green, blue, 255) {}
 
@@ -61,11 +68,12 @@ namespace Duel6 {
             set(red, green, blue, alpha);
         }
 
-        void operator=(const Color & c){
+        Color& operator = (const Color & c){
             color[0] = c.color[0];
             color[1] = c.color[1];
             color[2] = c.color[2];
             color[3] = c.color[3];
+            return *this;
         }
 
         bool operator==(const Color &color) const {

--- a/source/ConsoleCommands.cpp
+++ b/source/ConsoleCommands.cpp
@@ -130,6 +130,35 @@ namespace Duel6 {
         }
     }
 
+    void ConsoleCommands::listMaps(Console &console, const Console::Arguments &args, Menu &menu) {
+        auto i = 0;
+        for(auto & path : menu.listMaps()){
+            console.printLine(Format("{0}: {1}") << i++ << path);
+        }
+        console.printLine(Format("^^ (use the map index in 'map' command)"));
+    }
+    void ConsoleCommands::runMap(Console &console, const Console::Arguments &args, Menu &menu) {
+        if (args.length() > 1) {
+            std::vector<std::string> paths;
+            auto maps = menu.listMaps();
+            for(size_t i = 1 ; i < args.length(); i ++){
+                size_t index = -1;
+                auto val = args.get(i);
+                std::istringstream(val) >> index;
+                if(index < 0 || index >= maps.size() || (index == 0 && val != "0")){
+                    console.printLine(Format("Invalid map index {0}") << val);
+                    return;
+                }
+                std::string path = menu.listMaps()[index] ;
+                console.printLine(Format(": run {1}") << path);
+                paths.push_back(path);
+            }
+            if(console.isActive()) {
+                console.toggle();
+            }
+            menu.play(paths);
+        }
+    }
     void ConsoleCommands::loadSkin(Console &console, const Console::Arguments &args, Menu &menu) {
         auto &profileMap = menu.getPersonProfiles();
         std::string bodyParts[] = {"Hair top", "Hair bottom", "Body outer", "Body inner", "Arm outer", "Arm inner",
@@ -286,6 +315,12 @@ namespace Duel6 {
         });
         console.registerCommand("skin", [&menu](Console &con, const Console::Arguments &args) {
             loadSkin(con, args, menu);
+        });
+        console.registerCommand("maps", [&menu](Console &con, const Console::Arguments &args) {
+            listMaps(con, args, menu);
+        });
+        console.registerCommand("map", [&menu](Console &con, const Console::Arguments &args) {
+            runMap(con, args, menu);
         });
         console.registerCommand("gun", [&gameSettings](Console &con, const Console::Arguments &args) {
             enableWeapon(con, args, gameSettings);

--- a/source/ConsoleCommands.cpp
+++ b/source/ConsoleCommands.cpp
@@ -142,10 +142,10 @@ namespace Duel6 {
             std::vector<std::string> paths;
             auto maps = menu.listMaps();
             for(size_t i = 1 ; i < args.length(); i ++){
-                size_t index = -1;
+                size_t index = 0;
                 auto val = args.get(i);
                 std::istringstream(val) >> index;
-                if(index < 0 || index >= maps.size() || (index == 0 && val != "0")){
+                if(index >= maps.size() || (index == 0 && val != "0")){
                     console.printLine(Format("Invalid map index {0}") << val);
                     return;
                 }

--- a/source/ConsoleCommands.h
+++ b/source/ConsoleCommands.h
@@ -66,6 +66,10 @@ namespace Duel6 {
 
         static void shotCollision(Console &console, const Console::Arguments &args, GameSettings &gameSettings);
 
+        static void listMaps(Console &console, const Console::Arguments &args, Menu &menu);
+
+        static void runMap(Console &console, const Console::Arguments &args, Menu &menu);
+
     public:
         static void registerCommands(Console &console, AppService &appService, Menu &menu, GameSettings &gameSettings);
     };

--- a/source/Game.cpp
+++ b/source/Game.cpp
@@ -52,6 +52,7 @@ namespace Duel6 {
         if (getRound().isOver()) {
             if (!getRound().isLast()) {
                 nextRound();
+
             }
         } else {
             getRound().update(elapsedTime);
@@ -147,6 +148,7 @@ namespace Duel6 {
             onRoundEnd();
         });
         round->start();
+        worldRenderer.prerenderBackground();
     }
 
     void Game::endRound() {

--- a/source/Menu.cpp
+++ b/source/Menu.cpp
@@ -438,6 +438,10 @@ namespace Duel6 {
     }
 
     void Menu::play() {
+        play(listMaps());
+    }
+
+    void Menu::play(std::vector<std::string> levels) {
         if (playerListBox->size() < 2) {
             showMessage("Can't play alone ...");
             SDL_Event event;
@@ -477,11 +481,6 @@ namespace Duel6 {
         }
         selectedMode.initializePlayers(playerDefinitions);
 
-        // Levels
-        std::vector<std::string> levels;
-        for (Size i = 0; i < levelList.getLength(); ++i) {
-            levels.push_back(levelList.getPath(i));
-        }
 
         // Game backgrounds
         std::vector<Size> backgrounds;
@@ -746,6 +745,14 @@ namespace Duel6 {
             playerListBox->addItem(players[pos]);
             controlSwitch[i]->setCurrent(controls[pos]);
         }
+    }
+
+    std::vector<std::string> Menu::listMaps() {
+        std::vector<std::string> levels;
+        for (Size i = 0; i < levelList.getLength(); ++i) {
+            levels.push_back(levelList.getPath(i));
+        }
+        return levels;
     }
 
     void Menu::eloShufflePlayers() {

--- a/source/Menu.h
+++ b/source/Menu.h
@@ -122,6 +122,10 @@ namespace Duel6 {
             return personProfiles;
         }
 
+        std::vector<std::string> listMaps();
+
+        void play(std::vector<std::string> levels);
+
     private:
         void beforeStart(Context *prevContext) override;
 

--- a/source/Player.cpp
+++ b/source/Player.cpp
@@ -491,7 +491,7 @@ namespace Duel6 {
             if (!isMoving()) {
                 animation = animations.getStand().get();
             } else {
-                sprite->setSpeed(getSpeed());
+                sprite->setSpeed(getVelocity().length());
                 animation = animations.getWalk().get();
                 sprite->setLooping(AnimationLooping::RepeatForever);
             }

--- a/source/PlayerSkin.cpp
+++ b/source/PlayerSkin.cpp
@@ -33,12 +33,17 @@ namespace Duel6 {
     PlayerSkin::PlayerSkin(const PlayerSkinColors &colors,
                            const TextureManager &textureManager,
                            const PlayerAnimations & animations)
-        : animations(animations),
+        : colors(colors),
+          animations(animations),
           textures(animations.generateAnimationTexture(textureManager, colors)) {
     }
 
     Texture PlayerSkin::getTexture() const {
         return textures;
+    }
+
+    const PlayerSkinColors & PlayerSkin::getColors() const {
+        return colors;
     }
 
     const PlayerAnimations & PlayerSkin::getAnimations() const {

--- a/source/PlayerSkin.h
+++ b/source/PlayerSkin.h
@@ -39,6 +39,7 @@
 namespace Duel6 {
     class PlayerSkin {
     private:
+        PlayerSkinColors colors;
         const PlayerAnimations &animations;
         Texture textures;
 
@@ -47,6 +48,8 @@ namespace Duel6 {
                    const PlayerAnimations &animations);
 
         Texture getTexture() const;
+
+        const PlayerSkinColors &getColors() const;
 
         const PlayerAnimations &getAnimations() const;
     };

--- a/source/PlayerSkinColors.cpp
+++ b/source/PlayerSkinColors.cpp
@@ -58,6 +58,13 @@ namespace Duel6 {
             this->color[i] = color;
         }
     }
+    PlayerSkinColors::PlayerSkinColors(const PlayerSkinColors &colors){
+        for (Size i = 0; i < 11; i++) {
+            this->color[i] = colors.color[i];
+        }
+        this->hair = colors.hair;
+        this->headBand = colors.headBand;
+    }
 
     PlayerSkinColors &PlayerSkinColors::operator=(const PlayerSkinColors &colors) {
         for (Size i = 0; i < 11; i++) {

--- a/source/PlayerSkinColors.h
+++ b/source/PlayerSkinColors.h
@@ -62,6 +62,8 @@ namespace Duel6 {
 
         explicit PlayerSkinColors(const Color &color);
 
+        PlayerSkinColors(const PlayerSkinColors &colors);
+
         PlayerSkinColors &operator=(const PlayerSkinColors &colors);
 
         PlayerSkinColors &set(BodyPart bodyPart, const Color &color) {

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -189,14 +189,26 @@ namespace Duel6 {
     }
 
     std::unique_ptr<Renderer> Video::createRenderer() {
+        int depthBufferBits;
+        SDL_GL_GetAttribute(SDL_GL_DEPTH_SIZE, &depthBufferBits);
+        Renderer::DEPTH_BUFFER_FORMAT format = Renderer::DEPTH_BUFFER_FORMAT::DEPTH;
+
 #if defined(D6_RENDERER_GL1)
         return std::make_unique<GL1Renderer>();
 #elif defined(D6_RENDERER_GLES2)
         return std::make_unique<GLES2Renderer>();
 #elif defined(D6_RENDERER_GLES3)
-        return std::make_unique<GLES3Renderer>();
+        switch(depthBufferBits){
+            case(16): format = Renderer::DEPTH_BUFFER_FORMAT::DEPTH16; break;
+            case(24): format = Renderer::DEPTH_BUFFER_FORMAT::DEPTH24; break;
+        }
+        return std::make_unique<GLES3Renderer>(format);
 #elif defined(D6_RENDERER_GL4)
-        return std::make_unique<GL4Renderer>();
+        switch(depthBufferBits){
+            case(16): format = Renderer::DEPTH_BUFFER_FORMAT::DEPTH16; break;
+            case(24): format = Renderer::DEPTH_BUFFER_FORMAT::DEPTH; break;
+        }
+        return std::make_unique<GL4Renderer>(format);
 #endif
 
         D6_THROW(VideoException, "Invalid renderer");

--- a/source/Video.cpp
+++ b/source/Video.cpp
@@ -142,7 +142,7 @@ namespace Duel6 {
         profile = SDL_GL_CONTEXT_PROFILE_ES;
 #elif defined(D6_RENDERER_GLES3)
         majorVersion = 3;
-        minorVersion = 0;
+        minorVersion = 1;
         profile = SDL_GL_CONTEXT_PROFILE_ES;
 #elif defined(D6_RENDERER_GL4)
         majorVersion = 4;

--- a/source/WorldRenderer.cpp
+++ b/source/WorldRenderer.cpp
@@ -465,11 +465,11 @@ namespace Duel6 {
         return Color(128, 0, 0, Uint8(200 - 200 * overlay));
     }
 
-    Color  WorldRenderer::getRoundStartFadeColor() const {
-        if(game.getRound().getRemainingYouAreHere() <= 0) {
+    Color  WorldRenderer::getRoundStartFadeColor(Float32 remainingTime) const {
+        if(remainingTime <= 0) {
             return Color::WHITE;
         }
-        Float32 intensity =  4 * (game.getRound().getRemainingYouAreHere() / D6_YOU_ARE_HERE_DURATION);
+        Float32 intensity =  4 * (remainingTime / D6_YOU_ARE_HERE_DURATION);
 
         Uint8 c = 255.0f * std::max(1.0f - intensity, 0.0f);
         Color result = Color(c,c,100 + 155.0f * std::max(1.0f - intensity, 0.0f)); //Blue darkness
@@ -478,11 +478,16 @@ namespace Duel6 {
 
     void WorldRenderer::fullScreen() const {
         const Player &player = game.getPlayers().front();
+        Float32 remainingTime = game.getRound().getRemainingYouAreHere();
+        renderer.clearBuffers(); // attempt to resolve rendering issues in Alcatraz
         setView(player.getView());
         renderer.enableDepthTest(false);
-        target->blitDepth();
-        Color c = getRoundStartFadeColor();
-        target->render(c);
+        if(remainingTime > 0) {
+            Color c = getRoundStartFadeColor(remainingTime);
+            target->render(c); // render texture with color blending (slower)
+        } else {
+            target->blit(); // faster
+        }
         renderer.enableDepthTest(true);
         video.setMode(Video::Mode::Perspective);
         view(player);

--- a/source/WorldRenderer.cpp
+++ b/source/WorldRenderer.cpp
@@ -484,6 +484,7 @@ namespace Duel6 {
         renderer.enableDepthTest(false);
         if(remainingTime > 0) {
             Color c = getRoundStartFadeColor(remainingTime);
+            target->blitDepth();
             target->render(c); // render texture with color blending (slower)
         } else {
             target->blit(); // faster

--- a/source/WorldRenderer.h
+++ b/source/WorldRenderer.h
@@ -116,6 +116,8 @@ namespace Duel6 {
 
         Color getGameOverOverlay() const;
 
+        Color getRoundStartFadeColor() const;
+
         void shotCollisionBox(const ShotList &shotList) const;
     };
 }

--- a/source/WorldRenderer.h
+++ b/source/WorldRenderer.h
@@ -38,7 +38,7 @@
 #include "FaceList.h"
 #include "ShotList.h"
 #include "Ranking.h"
-
+#include "renderer/RendererTarget.h"
 namespace Duel6 {
     class Game;
 
@@ -48,11 +48,13 @@ namespace Duel6 {
         const Video &video;
         const Game &game;
         Renderer &renderer;
-
+        std::unique_ptr<RendererTarget> target;
     public:
         WorldRenderer(AppService &appService, const Game &game);
 
         void render() const;
+
+        void prerenderBackground();
 
     private:
         void setView(const PlayerView &view) const;

--- a/source/WorldRenderer.h
+++ b/source/WorldRenderer.h
@@ -116,7 +116,7 @@ namespace Duel6 {
 
         Color getGameOverOverlay() const;
 
-        Color getRoundStartFadeColor() const;
+        Color getRoundStartFadeColor(Float32) const;
 
         void shotCollisionBox(const ShotList &shotList) const;
     };

--- a/source/renderer/Renderer.h
+++ b/source/renderer/Renderer.h
@@ -37,7 +37,7 @@
 #include "../Material.h"
 #include "RendererTypes.h"
 #include "RendererBuffer.h"
-
+#include "RendererTarget.h"
 namespace Duel6 {
     class FaceList;
 
@@ -129,6 +129,8 @@ namespace Duel6 {
         virtual void frame(const Vector &position, const Vector &size, Float32 width, const Color &color) = 0;
 
         virtual std::unique_ptr<RendererBuffer> makeBuffer(const FaceList &faceList) = 0;
+
+        virtual std::unique_ptr<RendererTarget> makeTarget(GLuint width, GLuint height) = 0;
     };
 }
 

--- a/source/renderer/Renderer.h
+++ b/source/renderer/Renderer.h
@@ -40,7 +40,7 @@
 #include "RendererTarget.h"
 namespace Duel6 {
     class FaceList;
-
+    class RendererTarget;
     class Renderer {
     public:
         struct Info {

--- a/source/renderer/Renderer.h
+++ b/source/renderer/Renderer.h
@@ -43,6 +43,11 @@ namespace Duel6 {
     class RendererTarget;
     class Renderer {
     public:
+        enum DEPTH_BUFFER_FORMAT {
+            DEPTH,    //ogl4
+            DEPTH16,  //ogl4 Intel
+            DEPTH24   //gles3
+        };
         struct Info {
             std::string vendor;
             std::string renderer;

--- a/source/renderer/RendererBase.cpp
+++ b/source/renderer/RendererBase.cpp
@@ -122,4 +122,8 @@ namespace Duel6 {
         line(p3, p4, width, color);
         line(p4, position, width, color);
     }
+
+    std::unique_ptr<RendererTarget> RendererBase::makeTarget(GLuint width, GLuint height) {
+        return std::make_unique<RendererTarget>(width, height);
+    }
 }

--- a/source/renderer/RendererBase.cpp
+++ b/source/renderer/RendererBase.cpp
@@ -28,8 +28,8 @@
 #include "RendererBase.h"
 
 namespace Duel6 {
-    RendererBase::RendererBase()
-            : projectionMatrix(Matrix::IDENTITY), viewMatrix(Matrix::IDENTITY), modelMatrix(Matrix::IDENTITY) {}
+    RendererBase::RendererBase(const Renderer::DEPTH_BUFFER_FORMAT depthBufferFormat)
+            :depthBufferFormat(depthBufferFormat), projectionMatrix(Matrix::IDENTITY), viewMatrix(Matrix::IDENTITY), modelMatrix(Matrix::IDENTITY) {}
 
     void RendererBase::setProjectionMatrix(const Matrix &m) {
         projectionMatrix = m;
@@ -124,6 +124,12 @@ namespace Duel6 {
     }
 
     std::unique_ptr<RendererTarget> RendererBase::makeTarget(GLuint width, GLuint height) {
-        return std::make_unique<RendererTarget>(width, height, *this);
+        GLuint usedDepthBufferFormat;
+        switch(depthBufferFormat){
+            case(Renderer::DEPTH_BUFFER_FORMAT::DEPTH): usedDepthBufferFormat = GL_DEPTH_COMPONENT; break;
+            case(Renderer::DEPTH_BUFFER_FORMAT::DEPTH16): usedDepthBufferFormat = GL_DEPTH_COMPONENT16; break;
+            case(Renderer::DEPTH_BUFFER_FORMAT::DEPTH24): usedDepthBufferFormat = GL_DEPTH_COMPONENT24; break;
+        }
+        return std::make_unique<RendererTarget>(usedDepthBufferFormat, width, height, *this);
     }
 }

--- a/source/renderer/RendererBase.cpp
+++ b/source/renderer/RendererBase.cpp
@@ -124,6 +124,6 @@ namespace Duel6 {
     }
 
     std::unique_ptr<RendererTarget> RendererBase::makeTarget(GLuint width, GLuint height) {
-        return std::make_unique<RendererTarget>(width, height);
+        return std::make_unique<RendererTarget>(width, height, *this);
     }
 }

--- a/source/renderer/RendererBase.h
+++ b/source/renderer/RendererBase.h
@@ -35,13 +35,14 @@ namespace Duel6 {
     class RendererBase
             : public Renderer {
     protected:
+        const DEPTH_BUFFER_FORMAT depthBufferFormat;
         Matrix projectionMatrix;
         Matrix viewMatrix;
         Matrix modelMatrix;
         Matrix mvpMatrix;
 
     public:
-        RendererBase();
+        RendererBase(const DEPTH_BUFFER_FORMAT depthBufferFormat);
 
         void setProjectionMatrix(const Matrix &m) override;
 

--- a/source/renderer/RendererBase.h
+++ b/source/renderer/RendererBase.h
@@ -29,7 +29,7 @@
 #define DUEL6_RENDERER_RENDERER_BASE_H
 
 #include "Renderer.h"
-
+#include "RendererTarget.h"
 namespace Duel6 {
 
     class RendererBase
@@ -71,6 +71,7 @@ namespace Duel6 {
                     const Vector &textureSize, const Material &material) override;
 
         void frame(const Vector &position, const Vector &size, Float32 width, const Color &color) override;
+        std::unique_ptr<RendererTarget> makeTarget(GLuint width, GLuint height) override;
     };
 }
 

--- a/source/renderer/RendererTarget.cpp
+++ b/source/renderer/RendererTarget.cpp
@@ -42,7 +42,7 @@ namespace Duel6 {
             D6_THROW(Exception, "incomplete frameBuffer ");
         }
         GLCHECK
-        GLenum att[1] = {GL_COLOR_ATTACHMENT0};//,GL_DEPTH_ATTACHMENT};
+        GLenum att[1] = {GL_COLOR_ATTACHMENT0};
         glDrawBuffers(1, att);
         GLCHECK
         if(glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {

--- a/source/renderer/RendererTarget.cpp
+++ b/source/renderer/RendererTarget.cpp
@@ -1,31 +1,58 @@
 #include "RendererTarget.h"
 #include "../Exception.h"
 #include <sstream>
+
+#define GLCHECK {auto e = glGetError(); if(e != GL_NO_ERROR){ D6_THROW(Exception, (std::string("errorrr ") + std::to_string(e)).c_str());}}
+
 namespace Duel6 {
-    RendererTarget::RendererTarget(GLuint width, GLuint height)
+    RendererTarget::RendererTarget(GLuint width, GLuint height, Renderer & renderer)
         : width(width),
-          height(height) {
+          height(height),
+          renderer(renderer){
 
         glGenFramebuffers(1, &fbo);
-        glBindFramebuffer(GL_FRAMEBUFFER, fbo);
         glGenTextures(1, &texture);
-        glBindTexture(GL_TEXTURE_2D, texture);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, 0);
+        glBindTexture(GL_TEXTURE_2D_ARRAY, texture);
+        glBindFramebuffer(GL_FRAMEBUFFER, fbo);
 
+        glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_S, GL_REPEAT);
+        glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_T, GL_REPEAT);
+
+
+
+        glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+        GLCHECK
+        glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, GL_RGBA, width, height, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+        GLCHECK
+        glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        GLCHECK
+        glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        GLCHECK
+        glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, texture, 0, 0);
+        GLCHECK
         glGenTextures(1, &depthTexture);
-        glBindTexture(GL_TEXTURE_2D, depthTexture);
-
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, width, height, 0, GL_DEPTH_COMPONENT,  GL_UNSIGNED_INT, NULL);
-
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, depthTexture, 0);
+        GLCHECK
+        glBindTexture(GL_TEXTURE_2D_ARRAY, depthTexture);
+        GLCHECK
+        glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, GL_DEPTH_COMPONENT24, width, height, 1, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, NULL);
+        GLCHECK
+        glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, depthTexture, 0, 0);
+        GLCHECK
         if(glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
-            GLenum e = glGetError();
             D6_THROW(Exception, "incomplete frameBuffer ");
         }
-
-        glBindTexture(GL_TEXTURE_2D, 0);
+        GLCHECK
+        GLenum att[1] = {GL_COLOR_ATTACHMENT0};//,GL_DEPTH_ATTACHMENT};
+        glDrawBuffers(1, att);
+        GLCHECK
+        if(glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+            D6_THROW(Exception, "incomplete frameBuffer ");
+        }
+        GLCHECK
+        glBindTexture(GL_TEXTURE_2D_ARRAY, 0);
+        GLCHECK
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        GLCHECK
     }
 
     RendererTarget::~RendererTarget() {
@@ -37,6 +64,7 @@ namespace Duel6 {
     void RendererTarget::use() {
         glBindFramebuffer(GL_FRAMEBUFFER, fbo);
     }
+
 
     void RendererTarget::stopUse() {
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
@@ -50,10 +78,18 @@ namespace Duel6 {
     void RendererTarget::blit() {
         glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo);
         glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
-
         glBlitFramebuffer(0, 0, width, height, 0, 0, width, height, GL_COLOR_BUFFER_BIT  |  GL_DEPTH_BUFFER_BIT, GL_NEAREST);
-
         glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
     }
 
+    void RendererTarget::blitDepth() {
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo);
+        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+        glBlitFramebuffer(0, 0, width, height, 0, 0, width, height, GL_DEPTH_BUFFER_BIT, GL_NEAREST);
+
+    }
+
+    void RendererTarget::render(Color & color) {
+        this->renderer.quadXY(Vector::ZERO, Vector((float)width, (float)height), Vector(1, 1), Vector(1, 1), Material::makeColoredTexture(texture, color));
+    }
 }

--- a/source/renderer/RendererTarget.cpp
+++ b/source/renderer/RendererTarget.cpp
@@ -1,0 +1,59 @@
+#include "RendererTarget.h"
+#include "../Exception.h"
+#include <sstream>
+namespace Duel6 {
+    RendererTarget::RendererTarget(GLuint width, GLuint height)
+        : width(width),
+          height(height) {
+
+        glGenFramebuffers(1, &fbo);
+        glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+        glGenTextures(1, &texture);
+        glBindTexture(GL_TEXTURE_2D, texture);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, 0);
+
+        glGenTextures(1, &depthTexture);
+        glBindTexture(GL_TEXTURE_2D, depthTexture);
+
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, width, height, 0, GL_DEPTH_COMPONENT,  GL_UNSIGNED_INT, NULL);
+
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, depthTexture, 0);
+        if(glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+            GLenum e = glGetError();
+            D6_THROW(Exception, "incomplete frameBuffer ");
+        }
+
+        glBindTexture(GL_TEXTURE_2D, 0);
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    }
+
+    RendererTarget::~RendererTarget() {
+        glDeleteFramebuffers(1, &fbo);
+        glDeleteTextures(1, &texture);
+        glDeleteTextures(1, &depthTexture);
+    }
+
+    void RendererTarget::use() {
+        glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+    }
+
+    void RendererTarget::stopUse() {
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    }
+
+    void RendererTarget::clear() {
+        use();
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+    }
+
+    void RendererTarget::blit() {
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo);
+        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+
+        glBlitFramebuffer(0, 0, width, height, 0, 0, width, height, GL_COLOR_BUFFER_BIT  |  GL_DEPTH_BUFFER_BIT, GL_NEAREST);
+
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+    }
+
+}

--- a/source/renderer/RendererTarget.cpp
+++ b/source/renderer/RendererTarget.cpp
@@ -5,7 +5,7 @@
 #define GLCHECK {auto e = glGetError(); if(e != GL_NO_ERROR){ D6_THROW(Exception, (std::string("errorrr ") + std::to_string(e)).c_str());}}
 
 namespace Duel6 {
-    RendererTarget::RendererTarget(GLuint width, GLuint height, Renderer & renderer)
+    RendererTarget::RendererTarget(const GLuint depthBufferFormat, GLuint width, GLuint height, Renderer & renderer)
         : width(width),
           height(height),
           renderer(renderer){
@@ -34,7 +34,7 @@ namespace Duel6 {
         GLCHECK
         glBindTexture(GL_TEXTURE_2D_ARRAY, depthTexture);
         GLCHECK
-        glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, GL_DEPTH_COMPONENT, width, height, 1, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, NULL);
+        glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, depthBufferFormat, width, height, 1, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, NULL);
         GLCHECK
         glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, depthTexture, 0, 0);
         GLCHECK

--- a/source/renderer/RendererTarget.cpp
+++ b/source/renderer/RendererTarget.cpp
@@ -34,7 +34,7 @@ namespace Duel6 {
         GLCHECK
         glBindTexture(GL_TEXTURE_2D_ARRAY, depthTexture);
         GLCHECK
-        glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, GL_DEPTH_COMPONENT24, width, height, 1, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, NULL);
+        glTexImage3D(GL_TEXTURE_2D_ARRAY, 0, GL_DEPTH_COMPONENT, width, height, 1, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, NULL);
         GLCHECK
         glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, depthTexture, 0, 0);
         GLCHECK

--- a/source/renderer/RendererTarget.h
+++ b/source/renderer/RendererTarget.h
@@ -6,17 +6,17 @@
 namespace Duel6 {
     class Renderer;
     class RendererTarget {
+    private:
+        GLuint fbo;
+
+        Texture texture;
+        Texture depthTexture;
+
+        GLuint width, height;
+        Renderer & renderer;
+
     public:
-    GLuint fbo;
-
-    Texture texture;
-    Texture depthTexture;
-
-    GLuint width, height;
-    Renderer & renderer;
-
-    public:
-        RendererTarget (GLuint width, GLuint height, Renderer & renderer);
+        RendererTarget (GLuint depthBufferFormat, GLuint width, GLuint height, Renderer & renderer);
 
         virtual ~RendererTarget ();
 

--- a/source/renderer/RendererTarget.h
+++ b/source/renderer/RendererTarget.h
@@ -1,0 +1,29 @@
+#ifndef DUEL6_RENDERER_FRAMEBUFFER_H
+#define DUEL6_RENDERER_FRAMEBUFFER_H
+
+#include "RendererTypes.h"
+
+namespace Duel6 {
+    class RendererTarget {
+    public:
+    GLuint fbo;
+
+    Texture texture;
+    Texture depthTexture;
+    GLuint width, height;
+    public:
+        RendererTarget (GLuint width, GLuint height);
+
+        virtual ~RendererTarget ();
+
+        void use();
+
+        void stopUse();
+
+        void clear();
+
+        void blit();
+
+    };
+}
+#endif

--- a/source/renderer/RendererTarget.h
+++ b/source/renderer/RendererTarget.h
@@ -2,17 +2,21 @@
 #define DUEL6_RENDERER_FRAMEBUFFER_H
 
 #include "RendererTypes.h"
-
+#include "Renderer.h"
 namespace Duel6 {
+    class Renderer;
     class RendererTarget {
     public:
     GLuint fbo;
 
     Texture texture;
     Texture depthTexture;
+
     GLuint width, height;
+    Renderer & renderer;
+
     public:
-        RendererTarget (GLuint width, GLuint height);
+        RendererTarget (GLuint width, GLuint height, Renderer & renderer);
 
         virtual ~RendererTarget ();
 
@@ -23,6 +27,14 @@ namespace Duel6 {
         void clear();
 
         void blit();
+
+        void blitDepth();
+
+        void render(Color & color);
+
+        Texture getTexture();
+
+        Texture getDepthTexture();
 
     };
 }

--- a/source/renderer/es3/GLES3Buffer.cpp
+++ b/source/renderer/es3/GLES3Buffer.cpp
@@ -95,7 +95,8 @@ namespace Duel6 {
         Float32 colorData[4] = {color.getRed() / 255.0f, color.getGreen() / 255.0f, color.getBlue() / 255.0f,
                                 color.getAlpha() / 255.0f};
         program.setUniform("color", colorData);
-
+        Float32 effectColorData[4] = {0,0,0,0};
+        program.setUniform("effectColor", effectColorData);
         glDrawArrays(GL_TRIANGLES, 0, elements);
     }
 

--- a/source/renderer/es3/GLES3Buffer.cpp
+++ b/source/renderer/es3/GLES3Buffer.cpp
@@ -122,8 +122,7 @@ namespace Duel6 {
         }
     }
 
-    void
-    GLES3Buffer::createFaceListTextureIndexBuffer(const FaceList &faceList, std::vector<Float32> &textureIndexBuffer) {
+    void GLES3Buffer::createFaceListTextureIndexBuffer(const FaceList &faceList, std::vector<Float32> &textureIndexBuffer) {
         const auto &faces = faceList.getFaces();
         textureIndexBuffer.reserve(faces.size() * 6);
 

--- a/source/renderer/es3/GLES3Buffer.h
+++ b/source/renderer/es3/GLES3Buffer.h
@@ -28,7 +28,7 @@
 #ifndef DUEL6_RENDERER_GLES3_BUFFER_H
 #define DUEL6_RENDERER_GLES3_BUFFER_H
 
-#include <GL/glew.h>
+#include "GLES3Types.h"
 #include "../RendererBuffer.h"
 #include "../../Vertex.h"
 #include "GLES3Program.h"

--- a/source/renderer/es3/GLES3Renderer.cpp
+++ b/source/renderer/es3/GLES3Renderer.cpp
@@ -41,8 +41,8 @@ namespace Duel6 {
     };
     static MaterialVertex materialPoints[4];
 
-    GLES3Renderer::GLES3Renderer()
-            : RendererBase(),
+    GLES3Renderer::GLES3Renderer(const Renderer::DEPTH_BUFFER_FORMAT depthBufferFormat)
+            : RendererBase(depthBufferFormat),
               colorVertexShader(GL_VERTEX_SHADER, "shaders/gles3/colorVertex.glsl"),
               colorFragmentShader(GL_FRAGMENT_SHADER, "shaders/gles3/colorFragment.glsl"),
               materialVertexShader(GL_VERTEX_SHADER, "shaders/gles3/materialVertex.glsl"),

--- a/source/renderer/es3/GLES3Renderer.h
+++ b/source/renderer/es3/GLES3Renderer.h
@@ -51,7 +51,7 @@ namespace Duel6 {
         GLES3Program colorProgram;
         GLES3Program materialProgram;
     public:
-        GLES3Renderer();
+        GLES3Renderer(const Renderer::DEPTH_BUFFER_FORMAT depthBufferFormat);
 
         Info getInfo() override;
 

--- a/source/renderer/es3/GLES3Types.h
+++ b/source/renderer/es3/GLES3Types.h
@@ -28,8 +28,7 @@
 #ifndef DUEL6_RENDERER_GLES3_TYPES_H
 #define DUEL6_RENDERER_GLES3_TYPES_H
 
-#include <GL/glew.h>
-
+#include <GLES3/gl31.h>
 namespace Duel6 {
     typedef GLuint Texture;
 

--- a/source/renderer/es3/GLES3Types.h
+++ b/source/renderer/es3/GLES3Types.h
@@ -30,6 +30,7 @@
 
 #include <GLES3/gl31.h>
 namespace Duel6 {
+    constexpr auto DEPTH_BUFFER_FORMAT = GL_DEPTH_COMPONENT24;
     typedef GLuint Texture;
 
     enum class BlendFunc {

--- a/source/renderer/gl4/GL4Renderer.cpp
+++ b/source/renderer/gl4/GL4Renderer.cpp
@@ -44,8 +44,8 @@ namespace Duel6 {
     };
     static MaterialVertex materialPoints[4];
 
-    GL4Renderer::GL4Renderer()
-            : RendererBase(),
+    GL4Renderer::GL4Renderer(const Renderer::DEPTH_BUFFER_FORMAT depthBufferFormat)
+            : RendererBase(depthBufferFormat),
               colorVertexShader(GL_VERTEX_SHADER, "shaders/gl4/colorVertex.glsl"),
               colorFragmentShader(GL_FRAGMENT_SHADER, "shaders/gl4/colorFragment.glsl"),
               materialVertexShader(GL_VERTEX_SHADER, "shaders/gl4/materialVertex.glsl"),

--- a/source/renderer/gl4/GL4Renderer.h
+++ b/source/renderer/gl4/GL4Renderer.h
@@ -52,7 +52,7 @@ namespace Duel6 {
         GL4Program materialProgram;
 
     public:
-        GL4Renderer();
+        GL4Renderer(const Renderer::DEPTH_BUFFER_FORMAT depthBufferFormat);
 
         Info getInfo() override;
 

--- a/source/renderer/gl4/GL4Types.h
+++ b/source/renderer/gl4/GL4Types.h
@@ -31,6 +31,7 @@
 #include <GL/glew.h>
 
 namespace Duel6 {
+    constexpr auto DEPTH_BUFFER_FORMAT = GL_DEPTH_COMPONENT16;
     typedef GLuint Texture;
 
     enum class BlendFunc {


### PR DESCRIPTION
Repro steps:
pres cmake nastavit renderer gl4 & zkompilovat
spustit na PC s Intel HD graphics GPU
spustit hru & start 
renderovani nyni funguje tak, ze se veskera staticka grafika v aktualnim levelu predrenderuje na zacatku kola do Frame Buffer Objectu  (trida RendererTarget, pouzita v tride WorldRenderer) a tenhle buffer se v kazdym snimku 'blitne'. V tom Frame Bufferu by mel byt zaroven ulozenej i depth buffer.
Vsechno krasne funguje na linuxu, ve windows s amd grafarnou, ale v Alcatrazu je na tom kompu integrovana Intel grafika a tam jsem narazil na problem, ze se nejspis nekde ztrati ta hloubka z depth bufferu. Projevuje se to tim, ze se hraci renderuji pres staticky sprajty a pres steny, voda trosku prekryva bloky atp.
Tys uz predtim nejaky problemy na Intel grafice resil, mohl by ses pokusit vyresit i tuhle zahadu? Ja to nemam poradne jak oddebugovat.
Chyba muze byt but v tom, ze se treba pred tim prerenderem jeste musi zapnout renderer.enableDepthTest(true). Nebo ze se treba vubec nepripoji ten depth buffer do toho Frame Bufferu, ale to bych podle me odhalil mym zevrubnym prokladanim GLCHECK makra.
Nebo se mozna musi jeste nekde neco postelovat v shaderech ... fakt nevim.
